### PR TITLE
Improve generated shell completion scripts

### DIFF
--- a/e2e/test_bash.py
+++ b/e2e/test_bash.py
@@ -49,6 +49,15 @@ def test_completes_directories(complgen_binary_path: Path):
                 assert completions == sorted(['foo', 'bar'])
 
 
+def test_completes_dir_with_spaces(complgen_binary_path: Path):
+    with completion_script_path(complgen_binary_path, '''cmd <PATH>;''') as completions_file_path:
+        with tempfile.TemporaryDirectory() as dir:
+            with set_working_dir(Path(dir)):
+                os.mkdir('dir with spaces')
+                completions = get_sorted_completions(completions_file_path, '''COMP_WORDS=(cmd); COMP_CWORD=1; _cmd; printf '%s\n' "${COMPREPLY[@]}"''')
+                assert completions == sorted(['dir with spaces'])
+
+
 def test_bash_uses_correct_transition_with_duplicated_literals(complgen_binary_path: Path):
     GRAMMAR = '''
 cmd <COMMAND> [--help];

--- a/e2e/test_bash.py
+++ b/e2e/test_bash.py
@@ -21,7 +21,8 @@ def completion_script_path(complgen_binary_path: Path, grammar: str) -> Generato
 
 
 def get_sorted_completions(completions_file_path: Path, input: str) -> list[str]:
-    bash_process = subprocess.run(['bash', '--noprofile', '--rcfile', completions_file_path, '-i'], input=input.encode(), stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
+    input = f'source {completions_file_path}\n' + input
+    bash_process = subprocess.run(['bash', '--noprofile', '--norc', '-i'], input=input.encode(), stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
     lines = bash_process.stdout.decode().splitlines()
     lines.sort()
     return lines

--- a/e2e/test_fish.py
+++ b/e2e/test_fish.py
@@ -101,6 +101,15 @@ def test_completes_directories(complgen_binary_path: Path):
                 assert completions == sorted([('bar/', 'Directory'), ('foo/', 'Directory')])
 
 
+def test_completes_dir_with_spaces(complgen_binary_path: Path):
+    with completion_script_path(complgen_binary_path, '''cmd <PATH>;''') as completions_file_path:
+        with tempfile.TemporaryDirectory() as dir:
+            with set_working_dir(Path(dir)):
+                os.mkdir('dir with spaces')
+                input = 'source {}; complete --command cmd --do-complete "cmd "'.format(completions_file_path)
+                completions = get_sorted_completions(input)
+                assert completions == sorted([('dir with spaces/', '')])
+
 
 def get_sorted_jit_fish_completions(complgen_binary_path: Path, grammar: str, completed_word_index: int, words_before_cursor: list[str]) -> list[tuple[str, str]]:
     process = subprocess.run([complgen_binary_path, 'complete', '-', 'fish', '--', str(completed_word_index)] + words_before_cursor, input=grammar.encode(), stdout=subprocess.PIPE, stderr=sys.stderr, check=True)

--- a/e2e/test_zsh.py
+++ b/e2e/test_zsh.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import stat
 import tempfile
 import contextlib
 import subprocess
@@ -24,7 +23,7 @@ def zsh_completions_from_stdout(stdout: str) -> list[tuple[str, str]]:
 
 
 def get_sorted_completions(generated_script_path: Path, input: str) -> list[tuple[str, str]]:
-    zsh_process = subprocess.run([generated_script_path, input], stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
+    zsh_process = subprocess.run(['zsh', generated_script_path, input], stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
     stdout = zsh_process.stdout.decode()
     completions = zsh_completions_from_stdout(stdout)
     completions.sort(key=lambda pair: pair[0])
@@ -43,8 +42,6 @@ def capture_script_path(completion_script: str) -> Generator[Path, None, None]:
         f.write("\n")
         f.write(capture_postamble_path.read_text())
         f.flush()
-        st = os.stat(f.name)
-        os.chmod(f.name, st.st_mode | stat.S_IEXEC)
         yield Path(f.name)
 
 

--- a/e2e/test_zsh.py
+++ b/e2e/test_zsh.py
@@ -111,6 +111,14 @@ def test_completes_directories(complgen_binary_path: Path):
                 assert get_sorted_completions(capture_zsh_path, 'cmd ') == sorted([('bar/', ''), ('foo/', '')])
 
 
+def test_completes_file_with_spaces(complgen_binary_path: Path):
+    with capture_grammar_completions(complgen_binary_path, '''cmd <PATH>;''') as capture_zsh_path:
+        with tempfile.TemporaryDirectory() as dir:
+            with set_working_dir(Path(dir)):
+                Path('file with spaces').write_text('dummy')
+                assert get_sorted_completions(capture_zsh_path, 'cmd ') == sorted([('file\\ with\\ spaces', '')])
+
+
 def get_jit_zsh_completions_expr(complgen_binary_path: Path, grammar: str, completed_word_index: int, words_before_cursor: list[str]) -> str:
     process = subprocess.run([complgen_binary_path, 'complete', '-', 'zsh', '--', str(completed_word_index)] + words_before_cursor, input=grammar.encode(), stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
     return process.stdout.decode()

--- a/src/fish.rs
+++ b/src/fish.rs
@@ -172,7 +172,7 @@ end
                         break
                     end
                 end
-                if test word_matched -ne 0
+                if test $word_matched -ne 0
                     continue
                 end
             end

--- a/src/zsh.rs
+++ b/src/zsh.rs
@@ -130,7 +130,7 @@ pub fn write_completion_script<W: Write>(buffer: &mut W, command: &str, dfa: &DF
             local word=${{words[$word_index]}}
             local word_matched=0
             for literal_id in {{1..$#literals}}; do
-                if [[ ${{literals[$literal_id]}} = $word ]]; then
+                if [[ ${{literals[$literal_id]}} = "$word" ]]; then
                     if [[ -v "state_transitions[$literal_id]" ]]; then
                         state=${{state_transitions[$literal_id]}}
                         word_index=$((word_index + 1))
@@ -164,11 +164,11 @@ pub fn write_completion_script<W: Write>(buffer: &mut W, command: &str, dfa: &DF
         local -a descrs
         for literal_id in ${{(k)state_transitions}}; do
             if [[ -v "descriptions[$literal_id]" ]]; then
-                args+=(${{literals[$literal_id]}})
+                args+=("${{literals[$literal_id]}}")
                 descrs+=("${{literals[$literal_id]}} (${{descriptions[$literal_id]}})")
             else
-                args+=(${{literals[$literal_id]}})
-                descrs+=(${{literals[$literal_id]}})
+                args+=("${{literals[$literal_id]}}")
+                descrs+=("${{literals[$literal_id]}}")
             fi
         done
         local joined=${{(j::)descrs}}


### PR DESCRIPTION
I added some double quotes around variables to prevent globbing and word splitting and turned the `completions` array into a string since to simplify the code. There are two user-visible changes:

1. Completions for filenames with spaces will no longer be split (but filenames with newlines still will be)
2. Added missing dollar sign in front of a Fish variable name