### PR TITLE
bash: Fix completions containing colons

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ for path in ~/.config/complgen/*.usage; do
     eval "
 _complgen_jit_$stem () {
     local words cword
-    _get_comp_words_by_ref -n = words cword
+    _get_comp_words_by_ref -n =: words cword
     local prefix="\${words[\$cword]}"
     local -a completions=(\$(complgen complete \"$HOME/.config/complgen/${stem}.usage\" bash --prefix="\$prefix" -- \${words[@]:1:\$cword-1}))
     for item in "\${completions[@]}"; do

--- a/e2e/bash/test_bash_shell_integration.py
+++ b/e2e/bash/test_bash_shell_integration.py
@@ -19,7 +19,7 @@ for path in {usage_files_dir}/*.usage; do
     eval "
 _complgen_jit_$stem () {{
     local words cword
-    _get_comp_words_by_ref -n = words cword
+    _get_comp_words_by_ref -n =: words cword
     local prefix="\${{words[\$cword]}}"
     local -a completions=(\$({complgen_binary_path} complete \"{usage_files_dir}/$stem.usage\" bash --prefix="\$prefix" -- \${{words[@]:1:\$cword-1}}))
     for item in "\${{completions[@]}}"; do
@@ -60,7 +60,7 @@ mycargo +<toolchain>;
         input = r'''COMP_WORDS=(mycargo +); COMP_CWORD=1; _complgen_jit_mycargo; printf '%s\n' "${COMPREPLY[@]}"'''
         assert get_sorted_bash_completions(usage_file_path, input) == sorted(['+foo', '+bar'])
 
-
+# This test also needs to be tested manually in an interactive shell
 def test_wordbreaks_chars(complgen_binary_path: Path):
     GRAMMAR = '''
 mygrep --color "use markers to highlight the matching strings"=<WHEN>;
@@ -69,3 +69,11 @@ mygrep --color "use markers to highlight the matching strings"=<WHEN>;
     with temp_usage_file_path(complgen_binary_path, GRAMMAR, 'mygrep') as usage_file_path:
         input = r'''COMP_WORDS=(mygrep --color=); COMP_CWORD=1; _complgen_jit_mygrep; printf '%s\n' "${COMPREPLY[@]}"'''
         assert get_sorted_bash_completions(usage_file_path, input) == sorted(['--color=always', '--color=never', '--color=auto'])
+
+
+# This test also needs to be tested manually in an interactive shell
+def test_colons(complgen_binary_path: Path):
+    GRAMMAR = 'colontest (b:c | b:d);'
+    with temp_usage_file_path(complgen_binary_path, GRAMMAR, 'colontest') as usage_file_path:
+        input = r'''COMP_WORDS=(colontest b); COMP_CWORD=1; _complgen_jit_colontest; printf '%s\n' "${COMPREPLY[@]}"'''
+        assert get_sorted_bash_completions(usage_file_path, input) == sorted(['b:c', 'b:d'])

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -85,5 +85,7 @@ def get_bash_completion_sh_path() -> str:
         return '/opt/homebrew/etc/profile.d/bash_completion.sh'
     elif os.path.exists('/etc/bash_completion'):
         return '/etc/bash_completion'
+    elif os.path.exists('/usr/share/bash-completion/bash_completion'):
+        return '/usr/share/bash-completion/bash_completion'
     else:
         assert False, "Make sure OS package bash-completion is installed"

--- a/src/bash.rs
+++ b/src/bash.rs
@@ -402,6 +402,7 @@ pub fn write_completion_script<W: Write>(buffer: &mut W, command: &str, dfa: &DF
     }
 
     write!(buffer, r#"
+    __ltrim_colon_completions "$prefix"
     return 0
 }}
 


### PR DESCRIPTION
Fixes #32 

I avoided adding a dependency on bash-completion by inlining the `__ltrim_colon_completions` function. You might think that the generated Bash script already depends on bash-completion because it uses `_get_comp_words_by_ref` but that function is also provided by the bash completions for git.


After replacing

```py
def get_sorted_bash_completions(completions_file_path: Path, input: str) -> list[str]:
    bash_process = subprocess.run(['bash', '--noprofile', '--rcfile', completions_file_path, '-i'], input=input.encode(), stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
```

with 

```py
def get_sorted_bash_completions(completions_file_path: Path, input: str) -> list[str]:
    input = f'source {completions_file_path}; source /usr/share/bash-completion/bash_completion\n' + input
    bash_process = subprocess.run(['bash', '--noprofile', '--norc', '-i'], input=input.encode(), stdout=subprocess.PIPE, stderr=sys.stderr, check=True)
```

the e2e tests ran correctly and successfully.

I added an e2e test for colons but it runs successfully even without my changes to the shell integration. However, my changes do make a difference when testing manually in an interactive shell.